### PR TITLE
feat: add copy button to decrypted notes page

### DIFF
--- a/resources/views/note/show.blade.php
+++ b/resources/views/note/show.blade.php
@@ -17,8 +17,38 @@
                     <textarea class="form-control" id="note-text" rows="8">{{ $note_text }}</textarea>
                 </div>
 
+                <div class="mb-3">
+                    <div class="d-grid">
+                        <button id="copy-button" type="button" class="btn btn-outline-secondary">
+                            Copy note
+                        </button>
+                    </div>
+                </div>
+
             </div>
         </div>
     </div>
 @endsection
 
+@push('scripts')
+    <script>
+        $(document).ready(function () {
+            $('#copy-button').click(function (e) {
+                e.preventDefault();
+
+                var note_text = document.getElementById("note-text");
+                var copy_btn = document.getElementById("copy-button");
+
+                /* Select the text field */
+                note_text.select();
+                note_text.setSelectionRange(0, 99999); /* For mobile devices */
+
+                /* Copy the text inside the text field */
+                navigator.clipboard.writeText(note_text.value);
+
+                note_text.classList.add("is-valid");
+                copy_btn.innerText = 'Copied!';
+            });
+        });
+    </script>
+@endpush


### PR DESCRIPTION
I've used the same logic as in the show-link page. And kept the layout the same as on the create page.

Hope you like it.
First PR, feedback is welcome.